### PR TITLE
Add support for removing squash-merged branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - run: go mod tidy
       - run: go build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - uses: goreleaser/goreleaser-action@v2
         with:

--- a/git/git.go
+++ b/git/git.go
@@ -209,6 +209,40 @@ func SymbolicRef(ref string) (string, error) {
 	return firstLine(output), err
 }
 
+func TreeRef(ref string) (string, error) {
+	output, err := execGitQuiet("rev-parse", ref+"^{tree}")
+	if err != nil {
+		return "", err
+	}
+	return firstLine(output), err
+}
+
+func MergeBase(a, b string) (string, error) {
+	output, err := execGitQuiet("merge-base", a, b)
+	if err != nil {
+		return "", err
+	}
+	return firstLine(output), nil
+}
+
+func CommitTree(args ...string) (string, error) {
+	args = append([]string{"commit-tree"}, args...)
+	output, err := execGitQuiet(args...)
+	if err != nil {
+		return "", err
+	}
+	return firstLine(output), nil
+}
+
+func Cherry(args ...string) (string, error) {
+	args = append([]string{"cherry"}, args...)
+	output, err := execGitQuiet(args...)
+	if err != nil {
+		return "", err
+	}
+	return firstLine(output), nil
+}
+
 func execGit(args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Stderr = os.Stderr

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/jacobwgillespie/git-sync
 
-go 1.16
+go 1.17


### PR DESCRIPTION
`git-sync` will now detect if a branch has been squash-merged like it does with merge commits currently.